### PR TITLE
Update turf version 4.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
-Demonstrates using [Turfjs](https://github.com/Turfjs/turf) in a [nodejs](http://nodejs.org/)
+Demonstrates using [Turfjs](http://turfjs.org/) in a [nodejs](http://nodejs.org/)
 [expressjs](http://expressjs.com/) server. Visiting the page will measure your bandwidth, add it to a map,
 and show a TIN of other people's network speeds.
 
@@ -16,7 +16,7 @@ With [Heroku](https://www.heroku.com/), just click the Deploy button above.
 Otherwise:
 
 ```sh
-$ git clone https://github.com/mapbox/turf-server-example.git
+$ git clone https://github.com/Turfjs/turf-server-example.git
 $ cd turf-server-example
 $ npm install
 $ npm start

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "turf example",
   "description": "A bandwidth meter test example using turf",
-  "repository": "https://github.com/mapbox/turf-server-sample",
+  "repository": "https://github.com/Turfjs/turf-server-example",
   "logo": "http://node-js-sample.herokuapp.com/node.svg",
   "keywords": ["node", "express", "static", "turf"]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turf-server-example",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "an example of using turf in a server context",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,7 @@
     "request": "^2.51.0",
     "simple-statistics": "^0.9.0",
     "transfer-rate": "^1.0.5",
-    "turf": "^1.3.2",
+    "@turf/turf": "^4.3.1",
     "xhr": "^2.0.1"
   },
   "devDependencies": {

--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,7 @@
 <div id='map'></div>
 <div class='pin-bottomleft col5 fill-white keyline-top keyline-right' id='overlay'>
     <div class='pad2x pad1y fill-darken0'>
-        <a href='https://github.com/mapbox/turf-server-example' class='icon github'>Clone on Github &amp; Run on Heroku</a>
+        <a href='https://github.com/Turfjs/turf-server-example' class='icon github'>Clone on Github &amp; Run on Heroku</a>
     </div>
     <div class='pad2'>
         <h3>Turfjs Server Example</h3>
@@ -30,7 +30,7 @@
             server context. Turf is loaded in a <a href='http://nodejs.org/'>node.js</a>
             app built with <a href='http://expressjs.com/'>express</a>, and
             calculates a <a href='http://en.wikipedia.org/wiki/Triangulated_irregular_network'>triangulated irregular network</a>
-            of geolocated network speeds around the globe with <a href='http://turfjs.org/static/docs/module-turf_tin.html'>turf.tin</a>
+            of geolocated network speeds around the globe with <a href='http://turfjs.org/docs/#tin'>turf.tin</a>
             </p>
         </div>
     </div>


### PR DESCRIPTION
Hi,
this PR updates turf to version 4.3.1, updates links to turfjs.org and also updates ip location service using freegeoip.net

I try the sample on Heroku:
![](https://d2ppvlu71ri8gs.cloudfront.net/items/323A3f1l063j11162410/Image%202017-05-23%20at%2011.29.07%20AM.png)

I think this example is hard to try. Deploying on heroku is fine, only a location by IP, but for a local testing something simpler can be easier, in my opinion.
